### PR TITLE
allow disabling auto parse in browser build, closes #28

### DIFF
--- a/dummy.js
+++ b/dummy.js
@@ -154,7 +154,9 @@ var updateDom = function() {
 };
 
 if(document && document.addEventListener) {
-  document.addEventListener('DOMContentLoaded', updateDom);
+  if(window.dummy_auto !== false) {
+    document.addEventListener('DOMContentLoaded', updateDom);
+  }
 
   Dummy$1.updateDom = updateDom;
 }

--- a/src/browser.js
+++ b/src/browser.js
@@ -77,7 +77,9 @@ const updateDom = function() {
 };
 
 if(document && document.addEventListener) {
-  document.addEventListener('DOMContentLoaded', updateDom);
+  if(window.dummy_auto !== false) {
+    document.addEventListener('DOMContentLoaded', updateDom);
+  }
 
   Dummy.updateDom = updateDom;
 }


### PR DESCRIPTION
```
<script>dummy_auto = false</script>
<script src="dummy.js"></script>
```